### PR TITLE
fix(AL-869): Set overrides as empty dict if value is None

### DIFF
--- a/src/alfred/base/config.py
+++ b/src/alfred/base/config.py
@@ -24,6 +24,7 @@ class Configuration:
         """
         Returns client configuration for Alfred V1.
         """
+        overrides = overrides or {}
         return {
             "version": 1,
             "base_url": overrides.get("base_url", "https://app.tagshelf.com"),


### PR DESCRIPTION
Ticket: [AL-869](https://tagshelf.atlassian.net/browse/AL-869)

## Changes

Set `overrides` as empty dictionary if the provided argument is `None` to avoid `AttributeError` when fetching values.

[AL-869]: https://tagshelf.atlassian.net/browse/AL-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ