### PR TITLE
fix: when parsing, use the response headers to get the content-type.

### DIFF
--- a/src/alfred/http/http_client.py
+++ b/src/alfred/http/http_client.py
@@ -256,13 +256,12 @@ class HttpClient:
         """
 
         # Get the response type based on the content type header.
-        accept = response.request.headers.get("Accept")
-        content_type = response.request.headers.get("Content-Type").split(';')[0]
+        content_type = response.headers.get("Content-Type").split(';')[0]
         reversed_response_type_header_mapping = {v: k for k, v in RESPONSE_TYPE_HEADER_MAPPING.items()}
         response_type = reversed_response_type_header_mapping.get(content_type)
 
         try:
-            if accept == 'application/xml' and response_type == ResponseType.JSON:
+            if response_type == ResponseType.XML:
                 return ET.fromstring(response.text)
             elif response_type == ResponseType.JSON:
                 return response.json()


### PR DESCRIPTION
### Issue/Ticket: [AL-864](https://tagshelf.atlassian.net/browse/AL-864)


Changes
In my previous PR, I push a bug that was using the request headers to determine tha content type of the response. Leading to false data parsing. This PR fixes that and remove the use of the Accept header for parsing

[AL-864]: https://tagshelf.atlassian.net/browse/AL-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ