### PR TITLE
fix: Update domain methods to expect a tuple instead of Response

### DIFF
--- a/src/alfred/rest/data_points/v1.py
+++ b/src/alfred/rest/data_points/v1.py
@@ -17,4 +17,5 @@ class DataPoints(DataPointsBase):
         Args:
         - file_id: Unique identifier of the File.
         """
-        return self.http_client.get(f"/api/values/file/{file_id}")
+        parsed_resp, _ = self.http_client.get(f"/api/values/file/{file_id}")
+        return parsed_resp

--- a/src/alfred/rest/jobs/v1.py
+++ b/src/alfred/rest/jobs/v1.py
@@ -1,5 +1,5 @@
 # Native imports
-from typing import Any, Text
+from typing import Text
 
 # Project imports
 from src.alfred.rest.jobs.typed import CreateJobDict
@@ -18,7 +18,8 @@ class Jobs(JobsBase):
         Args:
         - job: Job creation parameters.
         """
-        return self.http_client.post("/api/job/create", data=job)
+        parsed_resp, _ = self.http_client.post("/api/job/create", data=job)
+        return parsed_resp
 
     def get(self, job_id: Text):
         """
@@ -27,4 +28,5 @@ class Jobs(JobsBase):
         Args:
         - job_id: Unique identifier of the Job.
         """
-        return self.http_client.get(f"/api/job/detail/{job_id}")
+        parsed_resp, _ = self.http_client.get(f"/api/job/detail/{job_id}")
+        return parsed_resp

--- a/src/alfred/rest/sessions/v1.py
+++ b/src/alfred/rest/sessions/v1.py
@@ -14,7 +14,8 @@ class Sessions(SessionsBase):
         """
         Creates a new Session.
         """
-        return self.http_client.post("/api/deferred/create")
+        parsed_resp, _ = self.http_client.post("/api/deferred/create")
+        return parsed_resp
 
     def get(self, session_id: Text):
         """
@@ -23,4 +24,5 @@ class Sessions(SessionsBase):
         Args:
         - session_id: Unique identifier of the Session.
         """
-        return self.http_client.get(f"/api/deferred/detail/{session_id}")
+        parsed_resp, _ = self.http_client.get(f"/api/deferred/detail/{session_id}")
+        return parsed_resp


### PR DESCRIPTION
## Changes
Updated all domain methods (except for `Files` domain that already handles it correctly) to expect a tuple containing a parsed response and the raw response from the HTTP request instead of just the raw response. 