### PR TITLE
fix(AL-871): Fixed bad imports

### DIFF
--- a/src/alfred/base/constants.py
+++ b/src/alfred/base/constants.py
@@ -1,4 +1,4 @@
-from alfred.http.typed import ResponseType
+from src.alfred.http.typed import ResponseType
 
 # Response type/header mapping
 RESPONSE_TYPE_HEADER_MAPPING = {

--- a/src/alfred/rest/files/v1.py
+++ b/src/alfred/rest/files/v1.py
@@ -5,7 +5,7 @@ from io import BufferedReader
 from urllib.parse import unquote
 
 # Project imports
-from alfred.rest.files.typed import *  # pylint: disable=W0401, W0614
+from src.alfred.rest.files.typed import *  # pylint: disable=W0401, W0614
 from src.alfred.http.http_client import HttpClient
 from src.alfred.base.exceptions import AlfredMissingArgument
 from .base import FilesBase


### PR DESCRIPTION
Ticket: [AL-871](https://tagshelf.atlassian.net/browse/AL-871)
## Changes

Fixed bad imports which are taking into reference the library name instead of the project directory structure. It doesn't impact the usage of the library but does crash on local tests.

This was introduced during changes on AL-871.

[AL-871]: https://tagshelf.atlassian.net/browse/AL-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ