### PR TITLE
fix(AL-895): File method not sending metadata and session id

### DIFF
--- a/src/alfred/rest/files/v1.py
+++ b/src/alfred/rest/files/v1.py
@@ -1,5 +1,6 @@
 # Native imports
 import os
+import json
 from typing import Text
 from io import BufferedReader
 from urllib.parse import unquote
@@ -48,13 +49,17 @@ class Files(FilesBase):
         if not filename:
             raise AlfredMissingArgument("filename must be provided.")
 
-        files = [("file", (filename, file, "application/octet-stream"))]
-
-        data = {key: value for key, value in payload.items() if key != "file"}
+        files = [
+            ("file", (filename, file, "application/octet-stream")),
+            ("session_id", (None, payload["session_id"], "text/plain")),
+            (
+                "metadata",
+                (None, json.dumps(payload.get("metadata")), "application/json"),
+            ),
+        ]
 
         parsed_resp, _ = self.http_client.post(
             "/api/file/uploadfile",
-            data=data,
             files=files,
             headers={"content-type": None},
         )


### PR DESCRIPTION
**Jira Ticket**: [AL-895](https://tagshelf.atlassian.net/browse/AL-895)

## Changes Implemented

- Removed the `data` object from the `/api/file/uploadfile` API call to address the issue where `session_id` and `metadata` parameters were not being utilized.
- Added the previously removed parameters (`session_id` and `metadata`) to the file parameters so they can be correctly handled as multipart data during the file upload process.

**Details:**
- The `session_id` and `metadata` are now included as part of the multipart/form-data payload in the file upload request. This ensures that these parameters are transmitted correctly and linked with the uploaded files.
- Updated the implementation to comply with the HTTP multipart request standards, ensuring all necessary parameters are recognized and processed correctly during the file upload.

[AL-895]: https://tagshelf.atlassian.net/browse/AL-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
