### PR TITLE
fix: ues old release-please-action until they finish changes

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -37,7 +37,8 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       environment: ${{ steps.target.outputs.environment }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      # - uses: googleapis/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           release-type: python


### PR DESCRIPTION

# Alfred python CI - release-please

Uses "old" release-please-action org (the repo was archived yesterday) until they finish doing all the changes.
