### PR TITLE
fix: release-please-action org rename and typo

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -39,12 +39,11 @@ jobs:
       environment: ${{ steps.target.outputs.environment }}
       pypi_url: ${{ steps.target.outputs.url }}
     steps:
-      # - uses: googleapis/release-please-action@v4
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: python
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.PPAT_TOKEN }}
           target-branch: ${{ github.ref_name }}
       - name: determine target environment
         id: target


### PR DESCRIPTION

# `google-github-actions` or was renamed to `googleapis`

Fixes google-github-actions was renamed to googleapis
